### PR TITLE
Add VEX file with vulnerabilities information to SBOM

### DIFF
--- a/pkg/new_sbom_file.sbom.vex.json
+++ b/pkg/new_sbom_file.sbom.vex.json
@@ -1,0 +1,118 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f947d3a51544d7685e5b61be1a3cb253941f7dd8afd183cf75c3b96acd0bbaff",
+  "author": "Unknown Author",
+  "timestamp": "2024-10-11T16:23:32.058913+02:00",
+  "last_updated": "2024-10-11T16:23:32.25975+02:00",
+  "version": 9,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41723"
+      },
+      "timestamp": "2024-10-11T16:23:32.058913+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/net@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-39325"
+      },
+      "timestamp": "2024-10-11T16:23:32.083048+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/net@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-3978"
+      },
+      "timestamp": "2024-10-11T16:23:32.109423+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/net@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-44487"
+      },
+      "timestamp": "2024-10-11T16:23:32.132826+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/net@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-44487"
+      },
+      "timestamp": "2024-10-11T16:23:32.157705+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/google.golang.org/grpc@v1.52.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45288"
+      },
+      "timestamp": "2024-10-11T16:23:32.18295+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/net@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-48795"
+      },
+      "timestamp": "2024-10-11T16:23:32.208102+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/golang.org/x/crypto@v0.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-24786"
+      },
+      "timestamp": "2024-10-11T16:23:32.233809+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/google.golang.org/protobuf@v1.28.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-28180"
+      },
+      "timestamp": "2024-10-11T16:23:32.25975+02:00",
+      "products": [
+        {
+          "@id": "pkg:go/gopkg.in/square/go-jose.v2@v2.6.0"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}


### PR DESCRIPTION
Dear project owners,
We are a group of researchers investigating the usefulness of augmenting Software Bills of Materials (SBOMs) with information about known vulnerabilities of third-party dependencies.

As claimed in previous interview-based studies, a major limitation—according to software practitioners—of existing SBOMs is the lack of information about known vulnerabilities.  For this reason, we would like to investigate how augmented SBOMs are received in open-source projects.

To this aim, we have identified popular open-source repositories on GitHub that provided SBOMs, statically detected vulnerabilities on their dependencies in the OSV database, and, based on its output, we have augmented your repository’s SBOM by leveraging the OpenVEX implementation of the Vulnerability Exploitability eXchange (VEX). 

The JSON file in this pull request consists of statements each indicating i) the software products (i.e., dependencies) that may be affected by a vulnerability. These are linked to the SBOM components through the @id field in their Persistent uniform resource locator (pURL); ii) a CVE affecting the product; iii) an impact status defined by VEX. By default, all statements have status `under_investigation` as it is not yet known whether these product versions are actually affected by the vulnerability. After investigating the vulnerability, further statuses can be `affected`, `not_affected`, `fixed`. It is possible to motivate the new status in a `justification` field (see https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf for more information). 
 
We open this pull request containing a VEX file related to the SBOM of your project, and hope it will be considered. 
We would also like to hear your opinion on the usefulness (or not) of this information by answering a 3-minute anonymous survey:
https://ww2.unipark.de/uc/sbom/

Thanks in advance, and regards,
Davide Fucci (Blekinge Institute of Technology, Sweden) 
Simone Romano and Giuseppe Scaniello (University of Salerno, Italy),
Massimiliano Di Penta (University of Sannio, Italy)
